### PR TITLE
Fix typos in Transactions page

### DIFF
--- a/input/pagecontent/transactions.xml
+++ b/input/pagecontent/transactions.xml
@@ -71,7 +71,7 @@
   
   <h3 id="store-health-certificate">Store Health Certificate</h3> 
   <p>
-  The Store Health Certificagte transaction is initiated by a <a href="actors.html#ddcc-generator">DDCC:VS Generation Service</a> against the <a href="actors.html#ddcc-repository">DDCC:VS Repository Service</a>.
+  The Store Health Certificate transaction is initiated by a <a href="actors.html#ddcc-generator">DDCC:VS Generation Service</a> against the <a href="actors.html#ddcc-repository">DDCC:VS Repository Service</a>.
   </p>
 
   {% include store_health_certificate.svg %}
@@ -86,7 +86,7 @@
 
   <h5 id="register-health-certificate-message-semantics-request"> Message Semantics Request</h5>
   <p>
-    The message semantics for the Store Health Certificate transaction utilizes a <a href="https://www.hl7.org/fhir/http.html#create">FHIR Create interaction</a> to create a <a href="StructureDefinition-DDCCDocument.html">DDCC Document</a>.
+    The message semantics for the Store Health Certificate transaction utilizes a <a href="https://www.hl7.org/fhir/http.html#create">FHIR create interaction</a> to create a <a href="StructureDefinition-DDCCDocument.html">DDCC Document</a>.
   </p>
   
   <h5 id="register-health-certificate-message-semantics-response"> Message Semantics Response</h5>


### PR DESCRIPTION
I noticed the word "Certificate" contained an extra letter. 

This also removes capitalization from "create" in the link "FHIR create interaction" to be consistent with the same link which is referenced on line 94.